### PR TITLE
feature: optional tls

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,8 +27,8 @@ type appConfig struct {
 	ListenAddr           string          `koanf:"listen_addr" validate:"required"`
 	DomainName           string          `koanf:"domain_name" validate:"required"`
 	ExternalPort         string          `koanf:"external_port" validate:"omitempty,numeric"`
-	TLSKey               string          `koanf:"tls_key" validate:"required"`
-	TLSCert              string          `koanf:"tls_cert" validate:"required"`
+	TLSKey               string          `koanf:"tls_key" validate:"required_with=TLSCert"`
+	TLSCert              string          `koanf:"tls_cert" validate:"required_with=TLSKey"`
 	SessionCookieName    string          `koanf:"session.cookie_name" validate:"required"`
 	SessionExpiration    time.Duration   `koanf:"session.expiration" validate:"required"`
 	StaticDomainMappings []DomainMapping `koanf:"domain_mappings"`

--- a/config_test.go
+++ b/config_test.go
@@ -18,8 +18,6 @@ func TestNewAppConfigDefaultValues(t *testing.T) {
 		provider: confmap.Provider(map[string]interface{}{
 			"api_token":     "abc",
 			"domain_name":   "example.com",
-			"tls_key":       "key.pem",
-			"tls_cert":      "cert.pem",
 			"phishlet_file": "phishlet.yml",
 		}, "."),
 	})
@@ -218,6 +216,38 @@ func TestNewAppConfigInvalidInput(t *testing.T) {
             tls_cert: cert.pem
             phishlet_file: phishlet.yml
             db_type: non_existing_type
+            session:
+                cookie_name: session_id2
+                expiration: 1h
+            domain_mappings:
+                - proxy: www.example.com
+                  target: www.google.com`,
+		},
+		{
+			name: "TLSKeyWithEmptyTLSCert",
+			data: `
+            api_token: abc
+            listen_addr: 0.0.0.0:4041
+            domain_name: example.com
+            external_port: 8091
+            tls_key: key.pem
+            phishlet_file: phishlet.yml
+            session:
+                cookie_name: session_id2
+                expiration: 1h
+            domain_mappings:
+                - proxy: www.example.com
+                  target: www.google.com`,
+		},
+		{
+			name: "TLSCertWithEmptyTLSKey",
+			data: `
+            api_token: abc
+            listen_addr: 0.0.0.0:4041
+            domain_name: example.com
+            external_port: 8091
+            tls_cert: cert.pem
+            phishlet_file: phishlet.yml
             session:
                 cookie_name: session_id2
                 expiration: 1h


### PR DESCRIPTION
make tls certificates optional, in this case the server must be behind a tls termination proxy, such as nginx